### PR TITLE
add assignment with '='

### DIFF
--- a/R/annotate-ast.R
+++ b/R/annotate-ast.R
@@ -123,7 +123,7 @@ annotate_ast <- function(ast) {
     # for assignments we really want to check rhs
     # and then also assign cpp type to LHS as well as expression
     # for later symbol lookup
-    is_assigment <- first_element_chr == "<-"
+    is_assigment <- first_element_chr == "<-" || first_element_chr == "="
     lhs_is_name <- "ast_node_name" %in% class(tail_elements[[1L]])
     if (is_assigment && lhs_is_name) {
       current_node$check_and_register_assignment()

--- a/R/ast-classes.R
+++ b/R/ast-classes.R
@@ -1556,6 +1556,7 @@ ast_node_type_scalar_numeric <- R6::R6Class(
 
 element_type_map <- new.env(parent = emptyenv())
 element_type_map[["<-"]] <- ast_node_assignment
+element_type_map[["="]] <- ast_node_assignment
 element_type_map[["{"]] <- ast_node_block
 element_type_map[["function"]] <- ast_node_function
 element_type_map[["arma_pairlist"]] <- ast_node_arma_pairlist

--- a/tests/testthat/test-compile.R
+++ b/tests/testthat/test-compile.R
@@ -528,7 +528,6 @@ test_that("for loops without a loop variable is deterministic", {
   expect_equal(code1, code2)
 })
 
-
 test_that("test assign with '='", {
   assign2 <- function(x) {
     x2 = x

--- a/tests/testthat/test-compile.R
+++ b/tests/testthat/test-compile.R
@@ -527,3 +527,13 @@ test_that("for loops without a loop variable is deterministic", {
   code2 <- translate(fun, "wat")$cpp_code
   expect_equal(code1, code2)
 })
+
+
+test_that("test assign with '='", {
+  assign2 <- function(x) {
+    x2 = x
+    return(x2)
+  }
+  code <- translate(assign2, "wat")$cpp_code
+  expect_true(grepl("x2 = x", code, fixed = TRUE))
+})


### PR DESCRIPTION
Was surprised to find that `=` assignment does not work :-). There are different R coding styles, some of us prefer `=` over `<-`.