### PR TITLE
List return

### DIFF
--- a/R/ast-classes.R
+++ b/R/ast-classes.R
@@ -1426,6 +1426,29 @@ ast_node_diag <- R6::R6Class(
   )
 )
 
+ast_node_list <- R6::R6Class(
+  classname = "ast_node_list",
+  inherit = ast_node,
+  public = list(
+    compile = function() {
+      stopifnot(length(self$get_tail_elements()) >= 1L)
+      args <- vapply(
+        self$get_tail_elements(),
+        function (x) x$compile(),
+        character(1L)
+      )
+      self$emit(
+        "Rcpp::List::create(",
+        paste0(args, collapse = ", "),
+        ")"
+      )
+    },
+    get_cpp_type = function() {
+      "Rcpp::List"
+    }
+  )
+)
+
 ast_node_rep_int <- R6::R6Class(
   classname = "ast_node_rep_int",
   inherit = ast_node,
@@ -1592,6 +1615,7 @@ element_type_map[[":"]] <- ast_node_colon
 element_type_map[["rep.int"]] <- ast_node_rep_int
 element_type_map[["norm"]] <- ast_node_norm
 element_type_map[["diag"]] <- ast_node_diag
+element_type_map[["list"]] <- ast_node_list
 element_type_map[["crossprod"]] <- ast_node_crossprod
 element_type_map[["tcrossprod"]] <- ast_node_tcrossprod
 element_type_map[["colSums"]] <- ast_node_colsums

--- a/tests/testthat/test-compile.R
+++ b/tests/testthat/test-compile.R
@@ -536,3 +536,13 @@ test_that("test assign with '='", {
   code <- translate(assign2, "wat")$cpp_code
   expect_true(grepl("x2 = x", code, fixed = TRUE))
 })
+
+test_that("we can return lists", {
+  code <- translate(function(X) {
+    x <- 1
+    return(list(x, 1))
+  }, "wat")$cpp_code
+  expect_true(
+    grepl("Rcpp::List wat(", code, fixed = TRUE)
+  )
+})

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -281,3 +281,16 @@ test_that("svd works", {
     fun_r(X)
   )
 })
+
+test_that("multiple returns", {
+  fun_r <- function(X) {
+    q <- qr(X)
+    return(
+      list(qr.Q(q), qr.R(q))
+    )
+  }
+  fun <- compile(fun_r)
+  res <- fun(matrix(1:100, 10, 10))
+  expect_true(is.list(res))
+  expect_equal(length(res), 2)
+})


### PR DESCRIPTION
A first implementation of unnamed lists. This allows multiple return values as described in #79  Also closes #79